### PR TITLE
feat: Combine !list and !status commands

### DIFF
--- a/AGENT_TASKS.md
+++ b/AGENT_TASKS.md
@@ -13,16 +13,14 @@
     *   **Change**: Add a new nullable `last_checked_at` field of type `datetime` to the `MonitoringTarget` SQLAlchemy model.
     *   **Action**: This will store the timestamp of the last time a check was run for each specific target.
 
-2.  **Create Database Migration**:
-    *   **Directory**: `migrations/versions/`
-    *   **Change**: Generate a new Alembic migration script to add the `last_checked_at` column to the `monitoring_targets` table in the database.
+2. There will be no database migration. Just delete it (note that the gcp infra is down righ tnow)
 
 3.  **Update Monitor Logic**:
     *   **File**: `src/monit
     *   **Change**: In the `run_checks_for_channel` method, after a check is successfully performed for a `target`, update its `last_checked_at` field to the current time and commit the change to the database session.
 
 4.  **Update `!list` Command**:
-    *   **File**: `src/cogs/config.py`
+    *   **File**: `src/cogs/monitoring.py`
     *   **Change**:
         *   Modify the `list` command to query `MonitoringTarget`s and retrieve the new `last_checked_at` field along with existing data.
         *   Reformat the output message to be a Markdown table inside a code block for proper alignment in Discord.

--- a/USER_DOCUMENTATION.md
+++ b/USER_DOCUMENTATION.md
@@ -34,8 +34,8 @@ Adds a new target to monitor. This command has three variations:
     *   **Without Radius**: `!add coordinates 45.5231 -122.6765` (uses PinballMap's default radius, 100Mi default radius)
     *   **With Radius**: `!add coordinates 47.6062 -122.3321 5`
 
-#### `!list` (or `!ls`)
-Displays a numbered list of all active monitoring targets in the current channel. The index numbers are used for other commands like `!rm`, `!poll_rate`, and `!notifications`.
+#### `!list` (or `!ls`, `!status`)
+Displays a detailed table of all active monitoring targets in the current channel. The table includes each target's index, poll rate, notification type, and the last time it was checked. The index numbers are used for commands like `!rm`.
 
 **Example:**
 ```
@@ -43,12 +43,13 @@ Displays a numbered list of all active monitoring targets in the current channel
 ```
 *Output:*
 ```
-Currently monitored targets:
-1. Location: Ground Kontrol Classic Arcade (ID: 99)
-2. City: Portland, OR (10 miles)
----
-Default Poll Rate: 60 minutes
-Default Notifications: machines
+┌───────┬──────────────────────────┬────────────┬───────────────┬────────────────┐
+│ Index │ Target                   │ Poll (min) │ Notifications │ Last Checked   │
+├───────┼──────────────────────────┼────────────┼───────────────┼────────────────┤
+│ 1     │ Location: Funland        │ 60         │ machines      │ 5 minutes ago  │
+│ 2     │ Coords: 40.71, -74.00    │ 30         │ all           │ 2 hours ago    │
+│ 3     │ City: Austin, TX         │ 60         │ machines      │ Never          │
+└───────┴──────────────────────────┴────────────┴───────────────┴────────────────┘
 ```
 
 #### `!check`
@@ -73,14 +74,6 @@ Sets how frequently (in minutes) the bot checks for updates.
 
 *   **Set for the whole channel**: `!poll_rate 30` (All targets will be checked every 30 minutes, unless they have a custom poll rate.)
 *   **Set for a specific target**: `!poll_rate 10 1` (Target #1 will be checked every 10 minutes, ignoring the channel default.)
-
-#### `!status`
-Shows a detailed overview of the bot's configuration for the channel, including default settings and a list of all targets with any custom settings they have.
-
-**Example:**
-```
-!status
-```
 
 #### `!rm <index>`
 Removes a monitoring target. The `index` corresponds to the number shown in the `!list` command.

--- a/src/database.py
+++ b/src/database.py
@@ -247,6 +247,13 @@ class Database:
                 config.last_poll_at = poll_time
                 session.commit()
 
+    def update_target_last_checked_time(self, target_id: int, checked_time: datetime) -> None:
+        """Update the last checked time for a specific monitoring target."""
+        with self.get_session() as session:
+            stmt = update(MonitoringTarget).where(MonitoringTarget.id == target_id).values(last_checked_at=checked_time)
+            session.execute(stmt)
+            session.commit()
+
     # Monitoring target methods
     def add_monitoring_target(self, channel_id: int, target_type: str, target_name: str, target_data: str = None, poll_rate_minutes: int = None, notification_types: str = None) -> None:
         """Add a monitoring target for a channel"""
@@ -330,6 +337,7 @@ class Database:
                     'target_data': target.target_data,
                     'poll_rate_minutes': target.poll_rate_minutes,
                     'notification_types': target.notification_types,
+                    'last_checked_at': target.last_checked_at,
                     'created_at': target.created_at
                 }
                 for target in targets

--- a/src/models.py
+++ b/src/models.py
@@ -41,6 +41,7 @@ class MonitoringTarget(Base):
     target_data = Column(String)  # location_id for location targets
     poll_rate_minutes = Column(Integer, default=60)  # Individual poll rate per target
     notification_types = Column(String, default='machines')  # Per-target notification type
+    last_checked_at = Column(DateTime(timezone=True), nullable=True)  # Last time this target was checked
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     # Relationships

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -86,6 +86,9 @@ class MachineMonitor(commands.Cog, name="MachineMonitor"):
                     submissions = await fetch_submissions_for_location(location_id, use_min_date=not is_manual_check)
                     all_submissions.extend(submissions)
 
+                # Update the last checked time for the target
+                self.db.update_target_last_checked_time(target['id'], datetime.now())
+
             if is_manual_check:
                 # For manual checks, show last 5 submissions regardless of whether we've seen them
                 # Sort by created_at descending and take first 5


### PR DESCRIPTION
Merges the functionality of !list and !status into a single command.

The new !list command (with !status as an alias) displays a formatted table of all monitored targets for a channel, including their poll rate, notification type, and last check time.

Adds last_checked_at to the MonitoringTarget model.

Updates monitor to record the last check time.

Updates user documentation and tests to reflect the changes.