### PR TITLE
Application: Add configurable DATABASE_PATH support (Litestream Phase 2)

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -30,9 +30,13 @@ except ImportError:
 
 
 class Database:
-    def __init__(self, db_path: str = "pinball_bot.db"):
+    def __init__(self, db_path: Optional[str] = None):
         """
         Initialize database with SQLAlchemy - supports both SQLite and PostgreSQL
+
+        Args:
+            db_path: Optional database file path. If None, uses DATABASE_PATH environment
+                    variable or defaults to "pinball_bot.db" for backward compatibility.
 
         DUAL-MODE ARCHITECTURE:
         - SQLite: Default mode for cost optimization (local files + cloud storage backup)
@@ -41,7 +45,16 @@ class Database:
         Switch modes by setting DB_TYPE environment variable:
         - DB_TYPE=sqlite (default, cost-optimized)
         - DB_TYPE=postgres (GCP Cloud SQL, higher cost but enterprise features)
+
+        DATABASE PATH CONFIGURATION:
+        - Local development: "pinball_bot.db" (default)
+        - Cloud Run deployment: "/tmp/pinball_bot.db" (writable filesystem)
+        - Custom environments: Set DATABASE_PATH environment variable
         """
+        # Get database path from parameter, environment variable, or default
+        if db_path is None:
+            db_path = os.getenv("DATABASE_PATH", "pinball_bot.db")
+
         db_type = os.getenv("DB_TYPE", "sqlite").lower()
 
         if db_type == "postgres":


### PR DESCRIPTION
## Summary
Implements Issue #29 - Add configurable database path support to enable different storage locations for different deployment environments, particularly for Cloud Run's `/tmp` writable filesystem.

## Changes
- **Database Constructor**: Now accepts optional `db_path` parameter
- **Environment Variable**: Uses `DATABASE_PATH` when no explicit path provided  
- **Backward Compatibility**: Defaults to `"pinball_bot.db"` when neither specified
- **Comprehensive Testing**: 5 new test cases covering all path resolution scenarios

## Path Resolution Priority
1. **Explicit Parameter**: `Database(db_path="/custom/path.db")` (highest priority)
2. **Environment Variable**: `DATABASE_PATH=/tmp/pinball_bot.db`
3. **Default**: `"pinball_bot.db"` (backward compatibility)

## Use Cases
- **Local Development**: `"pinball_bot.db"` (default, no changes needed)
- **Cloud Run Deployment**: `DATABASE_PATH="/tmp/pinball_bot.db"` (writable filesystem)
- **Custom Environments**: Set `DATABASE_PATH` environment variable as needed

## Testing
- ✅ **5 New Tests**: All path resolution scenarios covered
- ✅ **Functionality Tests**: Database operations work with custom paths
- ✅ **Environment Tests**: `monkeypatch` for isolated environment testing
- ✅ **Cleanup**: Proper temporary file management
- ✅ **All Lints Pass**: black, isort, flake8, mypy

## Dependencies
- **Depends on**: Issue #28 (Cloud Storage infrastructure) - independent change
- **Enables**: Issue #30 (Container Litestream setup) - needs configurable path

## Breaking Changes
None - fully backward compatible. Existing code continues to work unchanged.

🤖 Generated with [Claude Code](https://claude.ai/code)