### PR TITLE
fix: Update Claude GitHub Action to stable version and improve configuration

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,10 +18,11 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository
@@ -31,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v0.0.24
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 


### PR DESCRIPTION
## Summary
Fixes GitHub Actions failures by updating the Claude integration to use stable version and proper configuration.

## Changes Made
- **Version Update**: Changed from `@beta` to stable `v0.0.24` release
- **Permissions**: Added `write` permissions for `pull-requests` and `issues` (required for Claude to respond to mentions)
- **Timeout**: Added 10-minute timeout to prevent hanging workflows
- **Maintained Logic**: Preserved existing conditional logic for `@claude` mentions

## Problem Solved
The previous configuration was causing workflow runs to complete with `conclusion: "action_required"` instead of proper success/failure status. This was due to:

1. Using unstable `@beta` version
2. Missing write permissions preventing Claude from responding
3. No timeout causing potential hanging workflows

## Test Plan
- [x] Verify `ANTHROPIC_API_KEY` secret is configured
- [x] Update to stable action version
- [x] Add proper permissions and timeout
- [ ] Test workflow with actual `@claude` mention after merge

## Verification
After merging, the Claude GitHub Action should properly respond to `@claude` mentions in issues and PR comments without showing "action_required" status.

🤖 Generated with [Claude Code](https://claude.ai/code)