### PR TITLE
fix: Resolve KeyError 'target_data' in \!check command (Issue #68)

### DIFF
--- a/src/cogs/runner.py
+++ b/src/cogs/runner.py
@@ -302,7 +302,7 @@ class Runner(commands.Cog, name="Runner"):
                 source_data = (
                     target["target_name"]
                     if target_type == "latlong"
-                    else target["target_data"]
+                    else target["location_id"]
                 )
                 if not source_data:
                     logger.warning(
@@ -320,8 +320,8 @@ class Runner(commands.Cog, name="Runner"):
                 submissions = await fetch_submissions_for_coordinates(
                     lat, lon, radius, use_min_date=not is_manual_check
                 )
-            elif target_type == "location" and target["target_data"]:
-                location_id = int(target["target_data"])
+            elif target_type == "location" and target["location_id"]:
+                location_id = int(target["location_id"])
                 submissions = await fetch_submissions_for_location(
                     location_id, use_min_date=not is_manual_check
                 )


### PR DESCRIPTION
## Summary
- Fixes critical KeyError in \!check command that prevented manual monitoring checks
- Database field was migrated from `target_data` to `location_id` but code wasn't updated
- Added comprehensive test to catch and verify the fix

## Root Cause
The database schema was migrated to rename `target_data` to `location_id` in migration `5c8e4212f5ed`, but `src/cogs/runner.py` still tried to access `target["target_data"]`, causing KeyError crashes.

## Changes Made
### Code Fixes (3 locations in `src/cogs/runner.py`):
- **Line 305**: `target["target_data"]` → `target["location_id"]`  
- **Line 323**: `target["target_data"]` → `target["location_id"]`
- **Line 324**: `target["target_data"]` → `target["location_id"]`

### Test Coverage
- Added `test_run_checks_handles_location_id_field()` in `test_runner_e2e.py`
- Test reproduces the exact KeyError scenario with post-migration schema
- Validates that runner handles `location_id` field correctly

## Test Results
- ✅ **New test passes**: Catches KeyError scenario and verifies fix
- ✅ **All 188 tests pass**: No regressions introduced  
- ✅ **Pre-commit hooks pass**: Code formatting and linting clean

## Impact
- **Resolves Issue #68**: \!check command no longer crashes
- **Critical priority**: This was blocking manual monitoring functionality
- **Production ready**: Safe to deploy immediately

## Related
- Stacked on #[doc-cleanup-pr-number] for documentation improvements
- Part of resolving critical production issues before launch

🤖 Generated with [Claude Code](https://claude.ai/code)