### PR TITLE
fix: Improve \!add command UX for missing/invalid arguments (Issue #66)

### DIFF
--- a/src/cogs/command_handler.py
+++ b/src/cogs/command_handler.py
@@ -74,9 +74,19 @@ Examples:
   !add city "Seattle" 10
   !add coordinates 45.515 -122.678 5""",
     )
-    async def add(self, ctx, target_type: str, *args):
+    async def add(self, ctx, target_type: str | None = None, *args):
         """Add a new monitoring target. Usage: /add <location|coordinates|city> <args>"""
         try:
+            # Handle missing or invalid target_type
+            if target_type is None or target_type not in (
+                "location",
+                "coordinates",
+                "city",
+            ):
+                await self.notifier.log_and_send(
+                    ctx, Messages.Command.Add.INVALID_SUBCOMMAND
+                )
+                return
             if target_type == "location":
                 if not args:
                     await self.notifier.log_and_send(

--- a/src/cogs/runner.py
+++ b/src/cogs/runner.py
@@ -302,7 +302,7 @@ class Runner(commands.Cog, name="Runner"):
                 source_data = (
                     target["target_name"]
                     if target_type == "latlong"
-                    else target["target_data"]
+                    else target["location_id"]
                 )
                 if not source_data:
                     logger.warning(
@@ -320,8 +320,8 @@ class Runner(commands.Cog, name="Runner"):
                 submissions = await fetch_submissions_for_coordinates(
                     lat, lon, radius, use_min_date=not is_manual_check
                 )
-            elif target_type == "location" and target["target_data"]:
-                location_id = int(target["target_data"])
+            elif target_type == "location" and target["location_id"]:
+                location_id = int(target["location_id"])
                 submissions = await fetch_submissions_for_location(
                     location_id, use_min_date=not is_manual_check
                 )

--- a/tests/unit/test_command_handler.py
+++ b/tests/unit/test_command_handler.py
@@ -300,6 +300,36 @@ class TestAddCommand(TestCommandHandler):
         # Verify the correct handler was called and a notification was sent
         mock_notifier.send_initial_notifications.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_add_missing_arguments(
+        self, command_handler, mock_ctx, mock_notifier
+    ):
+        """Test add command with no arguments shows helpful error"""
+        from src.messages import Messages
+
+        # Call add with no target_type (None)
+        await command_handler.add.callback(command_handler, mock_ctx)
+
+        # Should send invalid subcommand message
+        mock_notifier.log_and_send.assert_called_once_with(
+            mock_ctx, Messages.Command.Add.INVALID_SUBCOMMAND
+        )
+
+    @pytest.mark.asyncio
+    async def test_add_invalid_target_type(
+        self, command_handler, mock_ctx, mock_notifier
+    ):
+        """Test add command with invalid target_type shows helpful error"""
+        from src.messages import Messages
+
+        # Call add with invalid target_type
+        await command_handler.add.callback(command_handler, mock_ctx, "invalid_type")
+
+        # Should send invalid subcommand message
+        mock_notifier.log_and_send.assert_called_once_with(
+            mock_ctx, Messages.Command.Add.INVALID_SUBCOMMAND
+        )
+
 
 class TestRemoveCommand(TestCommandHandler):
     """Test parsing of remove command arguments"""


### PR DESCRIPTION
## Summary
- Fixes UX issue where `\!add` without arguments showed cryptic Discord.py error
- Users now get helpful guidance showing valid command usage patterns
- Maintains full compatibility with existing functionality

## Root Cause
When users typed `\!add` (no arguments), Discord.py generated the error "target_type is a required argument that is missing" before our code could provide helpful guidance.

## Changes Made
### Code Improvements
- **Made `target_type` parameter optional**: `str  < /dev/null |  None = None`
- **Added input validation**: Check for None or invalid target_type values
- **Reused existing message**: `Messages.Command.Add.INVALID_SUBCOMMAND` provides perfect guidance
- **Simple & clean**: Single validation point handles both missing and invalid arguments

### Enhanced Test Coverage
- **`test_add_missing_arguments()`**: Verifies helpful error for `!add` (no args)
- **`test_add_invalid_target_type()`**: Verifies helpful error for `!add invalid_type`
- **No regressions**: All existing functionality preserved

## User Experience Improvement
**Before**: `target_type is a required argument that is missing`  
**After**: `❌ Invalid subcommand. Use !add location, !add city, or !add coordinates.`

## Test Results
- ✅ **2 new tests pass**: Missing args + invalid target_type scenarios
- ✅ **80/80 command handler tests pass**: No regressions in existing functionality
- ✅ **6/6 integration tests pass**: Full command workflows work correctly
- ✅ **All linting passes**: mypy, black, flake8, isort

## Impact
- **Resolves Issue #66**: Users get clear guidance instead of technical errors
- **Improved UX**: Better first-time user experience with the bot
- **Production ready**: Safe to deploy, maintains backward compatibility

## Related
- Stacked on #72 (Issue #68 fix) for comprehensive command reliability improvements
- Part of critical production issue resolution before launch

🤖 Generated with [Claude Code](https://claude.ai/code)