### PR TITLE
Fix monitoring loop startup crash and update litestream config

### DIFF
--- a/litestream.yml
+++ b/litestream.yml
@@ -16,7 +16,7 @@ dbs:
     replicas:
       - type: gcs
         bucket: ${LITESTREAM_BUCKET}
-        path: db
+        path: db-v2
         # Real-time replication settings
         sync-interval: 1s
         # Retention settings (aligned with GCS bucket lifecycle)

--- a/src/cogs/runner.py
+++ b/src/cogs/runner.py
@@ -440,13 +440,19 @@ class Runner(commands.Cog, name="Runner"):
         await self.bot.wait_until_ready()
         logger.info("✅ Bot ready, monitor loop will start shortly")
 
-        # Additional debug info
-        logger.info(f"🔍 Bot user: {self.bot.user}")
-        logger.info(f"🔍 Bot guilds: {len(self.bot.guilds)} guilds")
-        logger.info(
-            f"🔍 Task loop current iteration: {self.monitor_task_loop.current_loop}"
-        )
-        logger.info(f"🔍 Task loop is running: {self.monitor_task_loop.is_running()}")
+        # Additional debug info - with error handling for startup timing issues
+        try:
+            logger.info(f"🔍 Bot user: {self.bot.user}")
+            logger.info(f"🔍 Bot guilds: {len(self.bot.guilds)} guilds")
+            logger.info(
+                f"🔍 Task loop current iteration: {self.monitor_task_loop.current_loop}"
+            )
+            logger.info(
+                f"🔍 Task loop is running: {self.monitor_task_loop.is_running()}"
+            )
+        except Exception as e:
+            logger.warning(f"⚠️ Could not access bot debug info during startup: {e}")
+            logger.info("🔄 Debug info will be available once bot is fully initialized")
 
         # Run immediate first check to avoid waiting 60 minutes on startup
         await self._run_startup_checks()


### PR DESCRIPTION
## Summary
- Fix monitoring loop crash during Discord client initialization 
- Update litestream database path to db-v2

## Problem Solved
The monitoring loop was crashing on startup with `RuntimeError: Client has not been properly initialised` when trying to access `bot.user` and `bot.guilds` before the Discord client was fully ready. This prevented automatic monitoring from working - only manual `\!check` commands were functional.

## Changes Made
1. **Monitoring Fix**: Added error handling around debug logging in `before_monitor_task_loop()` to prevent crashes while preserving debug info when available
2. **Litestream Config**: Updated database replication path from `db` to `db-v2` in litestream.yml

## Test Plan
- [x] Code passes syntax check and linting
- [x] All 224 tests pass
- [x] Error handling preserves monitoring functionality
- [ ] Deploy and verify monitoring loop starts successfully in production
- [ ] Confirm automatic notifications work every minute

🤖 Generated with [Claude Code](https://claude.ai/code)